### PR TITLE
feat: Enhance test filtering with suite and test titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,18 @@ plugins: {
 ```json
 [
     {
-        "fullTitle": "some-title",
-        "browserId": "some-browser"
+        "fullTitle": "full test title",
+        "browserId": "browser-id"
+    },
+    {
+        "suiteTitle": "suite title (describe block)",
+        "browserId": "browser-id"
+    },
+    {
+        "title": "test title (it block)",
+        "browserId": "browser-id"
     }
 ]
 ```
+
+If multiple fields (`fullTitle`, `suiteTitle`, `title`) are specified for a single entry, `fullTitle` takes precedence, then `suiteTitle`, then `title`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,22 @@ module.exports = (testplane, opts) => {
 
         testCollection.disableAll();
 
-        input.forEach(({fullTitle, browserId}) => testCollection.enableTest(fullTitle, browserId));
+        input.forEach(({fullTitle, suiteTitle, title, browserId}) => {
+            if (fullTitle) {
+                testCollection.enableTest(fullTitle, browserId);
+            } else if (suiteTitle) {
+                testCollection.eachTest((test) => {
+                    if (test.parent && test.parent.title === suiteTitle) {
+                        testCollection.enableTest(test.fullTitle(), browserId);
+                    }
+                });
+            } else if (title) {
+                testCollection.eachTest((test) => {
+                    if (test.title === title) {
+                        testCollection.enableTest(test.fullTitle(), browserId);
+                    }
+                });
+            }
+        });
     });
 };

--- a/test/index.js
+++ b/test/index.js
@@ -20,11 +20,26 @@ describe('test filter', () => {
         return testplane;
     };
 
-    const mkTestCollectionStub = () => {
-        return {
+    const mkTestCollectionStub = (initialMockTests = []) => {
+        const tests = [];
+        const stub = {
             disableAll: sandbox.stub(),
-            enableTest: sandbox.stub()
+            enableTest: sandbox.stub(),
+            eachTest: (cb) => tests.forEach(cb)
         };
+
+        initialMockTests.forEach(({ title, parentTitle }) => {
+            const test = {
+                title,
+                fullTitle: () => (parentTitle ? `${parentTitle} ${title}` : title)
+            };
+            if (parentTitle) {
+                test.parent = { title: parentTitle };
+            }
+            tests.push(test);
+        });
+
+        return stub;
     };
 
     const initTestplane = async (testplane, opts = {}) => {
@@ -51,7 +66,7 @@ describe('test filter', () => {
     });
 
     describe('in master process of testplane', () => {
-        it('should enable each test from input file', async () => {
+        it('should enable each test from input file based on fullTitle', async () => {
             utils.readFile.withArgs('some/file.json').resolves([{
                 fullTitle: 'some-title',
                 browserId: 'some-browser'
@@ -65,6 +80,92 @@ describe('test filter', () => {
 
             assert.calledOnce(testCollection.disableAll);
             assert.calledWith(testCollection.enableTest, 'some-title', 'some-browser');
+        });
+
+        it('should enable tests based on suiteTitle', async () => {
+            utils.readFile.resolves([
+                {suiteTitle: 'suite1', browserId: 'br1'}
+            ]);
+
+            const testplane = mkTestplaneStub({isWorker: false});
+            await initTestplane(testplane);
+
+            const testCollection = mkTestCollectionStub([
+                { title: 'test1', parentTitle: 'suite1' },
+                { title: 'test2', parentTitle: 'suite1' },
+                { title: 'test3', parentTitle: 'suite2' }
+            ]);
+
+            testplane.emit(testplane.events.AFTER_TESTS_READ, testCollection);
+
+            assert.calledOnce(testCollection.disableAll);
+            assert.calledWith(testCollection.enableTest, 'suite1 test1', 'br1');
+            assert.calledWith(testCollection.enableTest, 'suite1 test2', 'br1');
+            assert.neverCalledWith(testCollection.enableTest, 'suite2 test3', 'br1');
+        });
+
+        it('should enable tests based on title', async () => {
+            utils.readFile.resolves([
+                {title: 'test1', browserId: 'br1'}
+            ]);
+
+            const testplane = mkTestplaneStub({isWorker: false});
+            await initTestplane(testplane);
+
+            const testCollection = mkTestCollectionStub([
+                { title: 'test1', parentTitle: 'suite1' },
+                { title: 'test2', parentTitle: 'suite1' }
+            ]);
+
+            testplane.emit(testplane.events.AFTER_TESTS_READ, testCollection);
+
+            assert.calledOnce(testCollection.disableAll);
+            assert.calledWith(testCollection.enableTest, 'suite1 test1', 'br1');
+            sinon.assert.neverCalledWith(testCollection.enableTest, 'suite1 test2', 'br1');
+        });
+
+        it('should prioritize fullTitle over suiteTitle and title', async () => {
+            utils.readFile.resolves([
+                {fullTitle: 'suite1 test1', suiteTitle: 'suite2', title: 'test3', browserId: 'br1'}
+            ]);
+
+            const testplane = mkTestplaneStub({isWorker: false});
+            await initTestplane(testplane);
+
+            const testCollection = mkTestCollectionStub([
+                { title: 'test1', parentTitle: 'suite1' },
+                { title: 'test2', parentTitle: 'suite2' },
+                { title: 'test3', parentTitle: 'suite3' }
+            ]);
+
+            testplane.emit(testplane.events.AFTER_TESTS_READ, testCollection);
+
+            assert.calledOnce(testCollection.disableAll);
+            assert.calledWith(testCollection.enableTest, 'suite1 test1', 'br1');
+            assert.neverCalledWith(testCollection.enableTest, sinon.match(/suite2/), 'br1');
+            assert.neverCalledWith(testCollection.enableTest, sinon.match(/test3/), 'br1');
+        });
+
+        it('should prioritize suiteTitle over title if fullTitle is not present', async () => {
+            utils.readFile.resolves([
+                {suiteTitle: 'suite2', title: 'test1', browserId: 'br1'}
+            ]);
+
+            const testplane = mkTestplaneStub({isWorker: false});
+            await initTestplane(testplane);
+
+            const testCollection = mkTestCollectionStub([
+                { title: 'test1', parentTitle: 'suite1' },
+                { title: 'test1', parentTitle: 'suite2' },
+                { title: 'test2', parentTitle: 'suite2' }
+            ]);
+
+            testplane.emit(testplane.events.AFTER_TESTS_READ, testCollection);
+
+            assert.calledOnce(testCollection.disableAll);
+            assert.calledWith(testCollection.enableTest, 'suite2 test1', 'br1');
+            assert.calledWith(testCollection.enableTest, 'suite2 test2', 'br1');
+            assert.neverCalledWith(testCollection.enableTest, 'suite1 test1', 'br1');
         });
 
         it('should run all tests if input file is empty', async () => {


### PR DESCRIPTION
This PR introduces the ability to filter tests by suite title (`suiteTitle`) or individual test title (`title`), in addition to the existing `fullTitle` option.

**Key Changes:**

*   Added support for new `suiteTitle` and `title` fields in the `inputFile`.
*   Implemented filter prioritization: `fullTitle` > `suiteTitle` > `title`.
*   Updated README and tests. Test stubs (`mkTestCollectionStub`) were refactored for improved clarity and conciseness.

This enhancement provides users with greater flexibility when selecting tests to run.